### PR TITLE
docs: correct spelling of Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for Obsidian.md
+	Catppuccin for Obsidian
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 


### PR DESCRIPTION
Corrected spelling from Obsidian.md to Obsidian.