### PR TITLE
Fix colors on Omnisearch's search results

### DIFF
--- a/scss/vendors/_plugins.scss
+++ b/scss/vendors/_plugins.scss
@@ -80,6 +80,10 @@
   background-color: rgb(var(--ctp-rosewater), 60%);
 }
 
+.omnisearch-result:not(.is-selected) .omnisearch-highlight.omnisearch-default-highlight {
+  background-color: rgb(var(--ctp-rosewater), 100%);
+}
+
 /*
 * MAKE.md
 */

--- a/scss/vendors/_plugins.scss
+++ b/scss/vendors/_plugins.scss
@@ -84,6 +84,15 @@
   background-color: rgb(var(--ctp-rosewater), 100%);
 }
 
+.omnisearch-result.is-selected {
+  .omnisearch-result__folder-path > span,
+  .omnisearch-result__extension,
+  .omnisearch-result__counter {
+    color: var(--text-faint);
+  }
+}
+
+
 /*
 * MAKE.md
 */


### PR DESCRIPTION
Fixes the following problems:

1. Text colour of the file extension, counter & path, on the current selected search result
2. Background colour of the highlighted text, on non-selected results

## Previews

| Before | After |
| --- | --- |
| ![image](https://github.com/catppuccin/obsidian/assets/49645243/a57bf2c3-829c-4983-ba04-4637d4e569e9) | ![image](https://github.com/catppuccin/obsidian/assets/49645243/ec787c87-37be-4a29-8692-5217241235f6) |
|  ![image](https://github.com/catppuccin/obsidian/assets/49645243/ec14f418-5535-4237-a9f1-ce4bd2ac70ae) | ![image](https://github.com/catppuccin/obsidian/assets/49645243/1cc1ae15-c1e0-41c8-8bae-cf90c09344c8) |
