### PR TITLE
fix: text-on-accent

### DIFF
--- a/scss/base/_ctp-style-settings.scss
+++ b/scss/base/_ctp-style-settings.scss
@@ -1136,7 +1136,8 @@ settings:
   --text-highlight-bg: rgb(var(--ctp-rosewater), 100%);
   --text-highlight-bg-active: rgb(var(--ctp-rosewater), 100%);
   --text-selection: rgb(var(--ctp-rosewater), 100%);
-  --text-on-accent: rgb(var(--ctp-base));
+  --text-on-accent: rgb(var(--ctp-mantle));
+  --text-on-accent-inverted: rgb(var(--ctp-mantle));
   --interactive-normal: rgb(var(--ctp-surface0));
   --interactive-hover: rgb(var(--ctp-surface1));
   --interactive-accent: rgb(var(--ctp-accent));


### PR DESCRIPTION
edit: just saw your issue, I hope you [the maintainer] are recovering well if you see this :heart: 
I will checkout the development branch and may make a pr there instead

- fixes checkbox styling
- uses mantle instead of base on top of accents

before and after:
![image](https://github.com/user-attachments/assets/39a54ca4-5b4b-44b2-b608-3138c1ef1bf2)
![image](https://github.com/user-attachments/assets/6ee0c1d1-55e1-412c-81a7-e2ab33047a18)
