### PR TITLE
Fix highlight coloring in date/datetime properties

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Catppuccin",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "minAppVersion": "1.0.0",
   "author": "Marshall Beckrich",
   "authorUrl": "https://github.com/catppuccin/obsidian"

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -48,3 +48,19 @@ input[type="number"]:focus-visible {
 .markdown-rendered button.copy-code-button {
   background-color: rgb(var(--ctp-crust));
 }
+
+// Fixing the text color on date parts of a date/datetime input
+input[type='date']::-webkit-datetime-edit-month-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-month-field:active,
+input[type='date']::-webkit-datetime-edit-month-field:focus,
+input[type='datetime-local']::-webkit-datetime-edit-month-field:focus,
+input[type='date']::-webkit-datetime-edit-day-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-day-field:active,
+input[type='date']::-webkit-datetime-edit-day-field:focus,
+input[type='datetime-local']::-webkit-datetime-edit-day-field:focus,
+input[type='date']::-webkit-datetime-edit-year-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-year-field:active,
+input[type='date']::-webkit-datetime-edit-year-field:focus,
+input[type='datetime-local']::-webkit-datetime-edit-year-field:focus {
+  color: var(--text-on-accent);
+}

--- a/scss/components/_inputs.scss
+++ b/scss/components/_inputs.scss
@@ -64,3 +64,14 @@ input[type='date']::-webkit-datetime-edit-year-field:focus,
 input[type='datetime-local']::-webkit-datetime-edit-year-field:focus {
   color: var(--text-on-accent);
 }
+
+// Changing the style of time parts in a datetime input
+input[type='datetime-local']::-webkit-datetime-edit-minute-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-minute-field:focus,
+input[type='datetime-local']::-webkit-datetime-edit-hour-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-hour-field:focus,
+input[type='datetime-local']::-webkit-datetime-edit-second-field:active,
+input[type='datetime-local']::-webkit-datetime-edit-second-field:focus {
+  background-color: var(--text-selection);
+  color: var(--text-on-accent);
+}

--- a/theme.css
+++ b/theme.css
@@ -2319,6 +2319,31 @@ input[type=number]:focus-visible {
   background-color: rgb(var(--ctp-crust));
 }
 
+input[type=date]::-webkit-datetime-edit-month-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-month-field:active,
+input[type=date]::-webkit-datetime-edit-month-field:focus,
+input[type=datetime-local]::-webkit-datetime-edit-month-field:focus,
+input[type=date]::-webkit-datetime-edit-day-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-day-field:active,
+input[type=date]::-webkit-datetime-edit-day-field:focus,
+input[type=datetime-local]::-webkit-datetime-edit-day-field:focus,
+input[type=date]::-webkit-datetime-edit-year-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-year-field:active,
+input[type=date]::-webkit-datetime-edit-year-field:focus,
+input[type=datetime-local]::-webkit-datetime-edit-year-field:focus {
+  color: var(--text-on-accent);
+}
+
+input[type=datetime-local]::-webkit-datetime-edit-minute-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-minute-field:focus,
+input[type=datetime-local]::-webkit-datetime-edit-hour-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-hour-field:focus,
+input[type=datetime-local]::-webkit-datetime-edit-second-field:active,
+input[type=datetime-local]::-webkit-datetime-edit-second-field:focus {
+  background-color: var(--text-selection);
+  color: var(--text-on-accent);
+}
+
 .cm-s-obsidian .cm-formatting-link.cm-url,
 .cm-s-obsidian .cm-url,
 .cm-s-obsidian .cm-link,


### PR DESCRIPTION
This PR changes the following items:

1. Update the foreground colour of highlighted text, on date sections in both `date` & `datetime-local` inputs
2. Updates the highlight colouring (both foreground + background), of the time section, in `datetime-local` inputs

I've also run `sass scss/main.scss theme.css`, and increased the version in the `manifest.json`.

## Previews

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/d8c361cb-5e8b-423f-9872-804eb23fa65a) | ![image](https://github.com/user-attachments/assets/6997b626-1082-44b1-adbc-b85be0a40070) |
| ![image](https://github.com/user-attachments/assets/f9e5602c-2ea1-463c-a4b5-400421b85dd3) | ![image](https://github.com/user-attachments/assets/af11fb30-295f-4a4e-9f3b-8037b4df6467) |
| ![image](https://github.com/user-attachments/assets/e58f94db-7ec7-49d9-87ca-83c9246740d0) | ![image](https://github.com/user-attachments/assets/e898a6f0-afec-4104-91bf-562c7e22752b) |
| ![image](https://github.com/user-attachments/assets/9c663592-edeb-4d7f-a037-0df04422aad4) | ![image](https://github.com/user-attachments/assets/553f113a-4466-4847-9ba4-f019ef0a5193) |



