### PR TITLE
docs(README): merge `About` into `Usage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,14 @@
 <img src="https://raw.githubusercontent.com/catppuccin/obsidian/main/assets/raw-flavor-screenshots/mocha.webp" alt="Preview of Mocha theme"/>
 </details>
 
-## About
-
-This is the Catppuccin theme for the note-taking app Obsidian.
-The theme is a constant work in progress, given the quick
-development pace of Obsidian itself and the user-made plugin
-scene. The theme uses a base64-encoded version of Friedrich Althausen's font [Vollkorn](http://vollkorn-typeface.com) as its default editor text.
-Runner up in 🎉 [Obsidian's 2022 Gems of the Year](https://forum.obsidian.md/t/gems-of-the-year-2022-winners/54903)
-awards. Thank you to everyone who voted.
-
 ## Usage
+
+> [!NOTE]  
+> The theme is a constant work in progress, given the quick development pace of Obsidian itself and the user-made plugin scene.
+> Currently, the default editor text uses a base64-encoded version of Friedrich Althausen's font [Vollkorn](http://vollkorn-typeface.com).
+>
+> The theme was also a runner up in 🎉 [Obsidian's 2022 Gems of the Year](https://obsidian.md/blog/2022-goty-winners/) awards.
+> Thank you to everyone who voted.
 
 This theme provides the full range of Catppuccin palettes when
 used with the
@@ -62,6 +60,7 @@ used with the
 plugin
 (see [here](https://help.obsidian.md/Extending+Obsidian/Community+plugins)
 for more on using plugins with Obsidian).
+
 This plugin will allow users to pick from several variations on
 Catppuccin, including accents for each color in the palette and
 one that features the full host of Catppuccin colors (the
@@ -87,7 +86,7 @@ A note on Style Settings setup from [pitoniak32](https://github.com/pitoniak32):
 
 > To install Style Settings, open Obsidian's `Preferences`, and navigate to the
 > OPTIONS section, select `Community plugins` and ensure that `Restricted Mode` is
-> off.
+> off.The theme uses a 
 >
 > Now you can search
 > for "[Style Settings](https://github.com/mgmeyers/obsidian-style-settings#obsidian-style-settings-plugin)"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A note on Style Settings setup from [pitoniak32](https://github.com/pitoniak32):
 
 > To install Style Settings, open Obsidian's `Preferences`, and navigate to the
 > OPTIONS section, select `Community plugins` and ensure that `Restricted Mode` is
-> off.The theme uses a 
+> off.
 >
 > Now you can search
 > for "[Style Settings](https://github.com/mgmeyers/obsidian-style-settings#obsidian-style-settings-plugin)"


### PR DESCRIPTION
I noticed that the Obsidian Gems of the Year 2022 link was out of date so replaced that to the new page its under. Also took the time to merge the About into the Usage in the form of a `[!NOTE]`.

I might come back to this README later on and simplify it a little to be more concise, if that's alright!