### PR TITLE
Add dist directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ theme.css.map
 scss-rebuild/
 node_modules/
 .sass-cache/
+dist/


### PR DESCRIPTION
The dist directory was deleted in aed52f97ed682dd071131540c9f2f94282135bc8 but wasn't added to `.gitignore`.

Related to #125 