### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/scss/pages/_canvas.scss
+++ b/scss/pages/_canvas.scss
@@ -6,7 +6,7 @@
 
 .canvas-node.is-selected .canvas-node-label,
 .canvas-node.is-focused .canvas-node-label {
-  color: rgb(var(--canvas-color));
+  color: var(--canvas-color);
 }
 
 .canvas-controls button:hover {
@@ -33,7 +33,7 @@
 
 .canvas-node.is-themed .canvas-node-container {
   border-width: 1px;
-  border-color: rgb(var(--canvas-color), 60%);
+  border-color: color-mix(in srgb, var(--canvas-color) 60%, transparent);
   box-shadow: none;
 }
 
@@ -44,5 +44,5 @@
 }
 
 .canvas-node.is-themed .canvas-node-content {
-  background-color: rgb(var(--canvas-color), 10%);
+  background-color: color-mix(in srgb, var(--canvas-color) 10%, transparent);
 }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
